### PR TITLE
feat(probook): intel_pstate, zstd zswap, NVMe scheduler, powertop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## HP ProBook 440 G8 PC/8A74
 - CPU: Intel i7-1165G7
 - GPU: Intel TigerLake-LP GT2 [Iris Xe Graphics]
-- RAM: 16GB
+- RAM: 32GB
 
 ## Custom CPU Hardware
 - CPU: AMD Ryzen 7 7800X3D
@@ -18,7 +18,8 @@
 - Motherboard: ASUS TUF GAMING X870-PLUS WIFI
 - RAM: Corsair Vengeance DDR5 6400MHz 64GB (2x32GB CL32)
 - Storage: WD Black SN850X 2TB NVMe PCIe 4.0 M.2 Gen4 16GT/s
-- Keyboard/Mouse: Logitech MK295
+- Keyboard: Keychron K3 Max
+- Mouse: Keychron M6 8K Ultra
 
 # Setup Guide
 

--- a/profiles/probook/default.nix
+++ b/profiles/probook/default.nix
@@ -43,10 +43,12 @@
     zfs.package = pkgs.zfs_2_4;
 
     kernelParams = [
+      "intel_pstate=active"
       "i915.enable_psr=1"
       "intel_iommu=on"
       "zswap.enabled=1"
       "zswap.max_pool_percent=15"
+      "zswap.compressor=zstd"
       "zfs.zfs_arc_max=8589934592"
     ];
 
@@ -76,6 +78,15 @@
 
   services.thermald.enable = true;
   services.power-profiles-daemon.enable = true;
+
+  services.udev.extraRules = ''
+    # NVMe: use none scheduler (hardware has its own queue)
+    ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/scheduler}="none"
+  '';
+
+  environment.systemPackages = with pkgs; [
+    powertop
+  ];
 
   virtualisation.docker = {
     enable = true;


### PR DESCRIPTION
- Add intel_pstate=active for native Intel frequency scaling on i7-1165G7
- Set zswap.compressor=zstd for better compression ratio
- Add NVMe I/O scheduler none via udev rule
- Add powertop for battery diagnostics